### PR TITLE
add processing file

### DIFF
--- a/process/data_processor.py
+++ b/process/data_processor.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from collections import Counter
 
 
-def collect_event_ids(data_frame):
+def collect_event_ids(data_frame, regex_pattern, column_names):
     """
     turns input data_frame into a 2 columned dataframe
     with columns: BlockId, EventSequence
@@ -17,15 +17,13 @@ def collect_event_ids(data_frame):
     """
     data_dict = OrderedDict()
     for _, row in data_frame.iterrows():
-        blk_id_list = re.findall(r"(blk_-?\d+)", row["Content"])
+        blk_id_list = re.findall(regex_pattern, row["Content"])
         blk_id_set = set(blk_id_list)
         for blk_id in blk_id_set:
             if not blk_id in data_dict:
                 data_dict[blk_id] = []
             data_dict[blk_id].append(row["EventId"])
-    data_df = pd.DataFrame(
-        list(data_dict.items()), columns=["BlockId", "EventSequence"]
-    )
+    data_df = pd.DataFrame(list(data_dict.items()), columns=column_names)
     return data_df
 
 
@@ -111,7 +109,9 @@ if __name__ == "__main__":
     print("data loaded")
 
     # Convert to blockId and EventSequence dataframe
-    events_df = collect_event_ids(train).merge(lab, on="BlockId")
+    re_pat = r"(blk_-?\d+)"
+    col_names = ["BlockId", "EventSequence"]
+    events_df = collect_event_ids(train, re_pat, col_names).merge(lab, on="BlockId")
 
     # Convert label column to binary
     events_df["Label"] = events_df["Label"].apply(lambda x: 1 if x == "Anomaly" else 0)

--- a/process/data_processor.py
+++ b/process/data_processor.py
@@ -7,7 +7,6 @@ import time
 import re
 from collections import OrderedDict
 from collections import Counter
-from scipy.special import expit
 
 
 def collect_event_ids(data_frame):
@@ -41,9 +40,8 @@ class FeatureExtractor(object):
         self.idf_vec = None
         self.events = None
         self.term_weighting = None
-        self.normalization = None
 
-    def fit_transform(self, X_seq, term_weighting=None, normalization=None):
+    def fit_transform(self, X_seq, term_weighting=None):
         """
         Fit and transform the training set
         X_Seq: ndarray,  log sequences matrix
@@ -51,7 +49,6 @@ class FeatureExtractor(object):
         normalization: None - not implemented yet
         """
         self.term_weighting = term_weighting
-        self.normalization = normalization
 
         # Convert into bag of words
         X_counts = []
@@ -70,14 +67,6 @@ class FeatureExtractor(object):
             self.idf_vec = np.log(num_instance / (df_vec + 1e-8))
             idf_matrix = X * np.tile(self.idf_vec, (num_instance, 1))
             X = idf_matrix
-
-        # normalization if parameter
-        if self.normalization == "zero-mean":
-            mean_vec = X.mean(axis=0)
-            self.mean_vec = mean_vec.reshape(1, num_event)
-            X = X - np.tile(self.mean_vec, (num_instance, 1))
-        elif self.normalization == "sigmoid":
-            X[X != 0] = expit(X[X != 0])  # expit is logistic sigmoid for ndarrays
 
         X_new = X
         print("Train data shape: {}-by-{}\n".format(X_new.shape[0], X_new.shape[1]))
@@ -107,11 +96,6 @@ class FeatureExtractor(object):
             idf_matrix = X * np.tile(self.idf_vec, (num_instance, 1))
             X = idf_matrix
 
-        # applies normalization if parameter
-        if self.normalization == "zero-mean":
-            X = X - np.tile(self.mean_vec, (num_instance, 1))
-        elif self.normalization == "sigmoid":
-            X[X != 0] = expit(X[X != 0])
         X_new = X
         print("Test data shape: {}-by-{}\n".format(X_new.shape[0], X_new.shape[1]))
         return X_new
@@ -121,8 +105,8 @@ if __name__ == "__main__":
 
     start = time.time()
 
-    # train = pd.read_csv("./train_subset.csv") # for testing
-    train = pd.read_csv("./HDFS_train.log_structured.csv")
+    train = pd.read_csv("./train_subset.csv")  # for testing
+    # train = pd.read_csv("./HDFS_train.log_structured.csv")
     lab = pd.read_csv("./anomaly_label.csv")
     print("data loaded")
 

--- a/process/data_processor.py
+++ b/process/data_processor.py
@@ -1,0 +1,155 @@
+"""
+loads and preprocesses the structured log data for anomoly prediction
+"""
+import numpy as np
+import pandas as pd
+import time
+import re
+from collections import OrderedDict
+from collections import Counter
+from scipy.special import expit
+
+
+def collect_event_ids(data_frame):
+    """
+    turns input data_frame into a 2 columned dataframe
+    with columns: BlockId, EventSequence
+    where EventSequence is a list of the events that happened to the block
+    """
+    data_dict = OrderedDict()
+    for _, row in data_frame.iterrows():
+        blk_id_list = re.findall(r"(blk_-?\d+)", row["Content"])
+        blk_id_set = set(blk_id_list)
+        for blk_id in blk_id_set:
+            if not blk_id in data_dict:
+                data_dict[blk_id] = []
+            data_dict[blk_id].append(row["EventId"])
+    data_df = pd.DataFrame(
+        list(data_dict.items()), columns=["BlockId", "EventSequence"]
+    )
+    return data_df
+
+
+class FeatureExtractor(object):
+    """
+    class for fitting and transforming the training set
+    then transforming the testing set
+    """
+
+    def __init__(self):
+        self.mean_vec = None
+        self.idf_vec = None
+        self.events = None
+        self.term_weighting = None
+        self.normalization = None
+
+    def fit_transform(self, X_seq, term_weighting=None, normalization=None):
+        """
+        Fit and transform the training set
+        X_Seq: ndarray,  log sequences matrix
+        term_weighting: None or `tf-idf`
+        normalization: None - not implemented yet
+        """
+        self.term_weighting = term_weighting
+        self.normalization = normalization
+
+        # Convert into bag of words
+        X_counts = []
+        for i in range(X_seq.shape[0]):
+            event_counts = Counter(X_seq[i])
+            X_counts.append(event_counts)
+        X_df = pd.DataFrame(X_counts)
+        X_df = X_df.fillna(0)
+        self.events = X_df.columns
+        X = X_df.values
+
+        num_instance, num_event = X.shape
+        # applies tf-idf if pararmeter
+        if self.term_weighting == "tf-idf":
+            df_vec = np.sum(X > 0, axis=0)
+            self.idf_vec = np.log(num_instance / (df_vec + 1e-8))
+            idf_matrix = X * np.tile(self.idf_vec, (num_instance, 1))
+            X = idf_matrix
+
+        # normalization if parameter
+        if self.normalization == "zero-mean":
+            mean_vec = X.mean(axis=0)
+            self.mean_vec = mean_vec.reshape(1, num_event)
+            X = X - np.tile(self.mean_vec, (num_instance, 1))
+        elif self.normalization == "sigmoid":
+            X[X != 0] = expit(X[X != 0])  # expit is logistic sigmoid for ndarrays
+
+        X_new = X
+        print("Train data shape: {}-by-{}\n".format(X_new.shape[0], X_new.shape[1]))
+        return X_new
+
+    def transform(self, X_seq):
+        """
+        transforms x test
+        X_seq: log sequence data
+        """
+
+        # converts into bag of words
+        X_counts = []
+        for i in range(X_seq.shape[0]):
+            event_counts = Counter(X_seq[i])
+            X_counts.append(event_counts)
+        X_df = pd.DataFrame(X_counts)
+        X_df = X_df.fillna(0)
+        empty_events = set(self.events) - set(X_df.columns)
+        for event in empty_events:
+            X_df[event] = [0] * len(X_df)
+        X = X_df[self.events].values
+
+        # applies tf-idf if pararmeter
+        num_instance, _ = X.shape
+        if self.term_weighting == "tf-idf":
+            idf_matrix = X * np.tile(self.idf_vec, (num_instance, 1))
+            X = idf_matrix
+
+        # applies normalization if parameter
+        if self.normalization == "zero-mean":
+            X = X - np.tile(self.mean_vec, (num_instance, 1))
+        elif self.normalization == "sigmoid":
+            X[X != 0] = expit(X[X != 0])
+        X_new = X
+        print("Test data shape: {}-by-{}\n".format(X_new.shape[0], X_new.shape[1]))
+        return X_new
+
+
+if __name__ == "__main__":
+
+    start = time.time()
+
+    # train = pd.read_csv("./train_subset.csv") # for testing
+    train = pd.read_csv("./HDFS_train.log_structured.csv")
+    lab = pd.read_csv("./anomaly_label.csv")
+    print("data loaded")
+
+    # Convert to blockId and EventSequence dataframe
+    events_df = collect_event_ids(train).merge(lab, on="BlockId")
+
+    # Convert label column to binary
+    events_df["Label"] = events_df["Label"].apply(lambda x: 1 if x == "Anomaly" else 0)
+
+    # select only events
+    events = events_df["EventSequence"].values
+
+    # init feature extractor
+    fe = FeatureExtractor()
+
+    # fit and transform x_train
+    print("fitting and transforming x train")
+    x_train = fe.fit_transform(events, term_weighting="tf-idf")
+
+    # transform x_test
+    print("transforming x test")
+    x_fake_test = fe.transform(events)
+
+    # x_train and x_fake_test should be equal
+    # x_train was fit and transformed
+    # x_fake_test was transformed on the fit parameters
+    # simple testing, to be removed
+    print("are the two results equal? ", np.array_equal(x_train, x_fake_test))
+
+    print("time taken :", time.time() - start)


### PR DESCRIPTION
- The full data set has 48 unique events, and the are expressed like :  '09a53393' '3d91fa85' 'd38aa58d' instead of E5, E6, E22
- since the step of taking the semi structured data and transforming it into structured turns the eventsequence list into columns, it may make sense to train/test split after the columns are created
- they have some work going on to split the anomalous data evenly between the train and test set, do we care?
- In the the total data set there are 16838 anomalies, and 558223 non-anomalies

When run on a 1000 row sub sample
```
Train data shape: 196-by-12
time taken : 0.6757140159606934
```


When run on the whole HDFS_train.log_structured.csv
```
Train data shape: 454524-by-48
time taken : 826.716805934906
```